### PR TITLE
issuers/vault: Switch to CSR signing

### DIFF
--- a/certify_suite_test.go
+++ b/certify_suite_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/cloudflare/cfssl/api/client"
 	"github.com/cloudflare/cfssl/config"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/vault/api"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -201,9 +201,11 @@ var _ = BeforeSuite(func() {
 		Expect(err).To(Succeed())
 
 		_, err = cli.Logical().Write("pki/roles/"+vaultConf.Role, map[string]interface{}{
-			"allowed_domains":  "myserver.com",
-			"allow_subdomains": true,
-			"allow_any_name":   true,
+			"allowed_domains":    "myserver.com",
+			"allow_subdomains":   true,
+			"allow_any_name":     true,
+			"key_type":           "any",
+			"allowed_other_sans": "1.3.6.1.4.1.311.20.2.3;utf8:*",
 		})
 		Expect(err).To(Succeed())
 	})


### PR DESCRIPTION
Using CSR signing instead of direct certificate issuing
means we can safely work over HTTP connections
without exposing the private key in the response.
It is still recommended not to use HTTP since
it could mean interception of the authentication
credentials.

Fixes #11