### PR TITLE
Unexport Connect, add CFFSL test for unencrypted connections

### DIFF
--- a/issuers/aws/aws_suite_test.go
+++ b/issuers/aws/aws_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestAws(t *testing.T) {
+func TestAWS(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Aws Suite")
+	RunSpecs(t, "AWS Suite")
 }

--- a/issuers/cfssl/cfssl.go
+++ b/issuers/cfssl/cfssl.go
@@ -62,7 +62,11 @@ func FromClient(v client.Remote) (*Issuer, error) {
 // connect and sends a request to validate server availability and
 // cache its cert.
 func (i *Issuer) connect(ctx context.Context) error {
-	i.remote = client.NewServerTLS(i.URL.String(), i.TLSConfig)
+	if i.TLSConfig != nil {
+		i.remote = client.NewServerTLS(i.URL.String(), i.TLSConfig)
+	} else {
+		i.remote = client.NewServer(i.URL.String())
+	}
 	// Add context to requests
 	i.remote.SetReqModifier(func(req *http.Request, _ []byte) {
 		*req = *req.WithContext(ctx)

--- a/issuers/cfssl/cfssl.go
+++ b/issuers/cfssl/cfssl.go
@@ -59,10 +59,9 @@ func FromClient(v client.Remote) (*Issuer, error) {
 	return i, nil
 }
 
-// Connect creates a new connection to the CFSSL server
-// and sends a request to validate server availability. If not called,
-// a connection will be made in the first Issue call.
-func (i *Issuer) Connect(ctx context.Context) error {
+// connect and sends a request to validate server availability and
+// cache its cert.
+func (i *Issuer) connect(ctx context.Context) error {
 	i.remote = client.NewServerTLS(i.URL.String(), i.TLSConfig)
 	// Add context to requests
 	i.remote.SetReqModifier(func(req *http.Request, _ []byte) {
@@ -84,10 +83,10 @@ func (i *Issuer) Connect(ctx context.Context) error {
 	return nil
 }
 
-// Issue issues a certificate with the provided options
+// Issue issues a certificate with the provided options.
 func (i *Issuer) Issue(ctx context.Context, commonName string, conf *certify.CertConfig) (*tls.Certificate, error) {
 	if i.remote == nil {
-		err := i.Connect(ctx)
+		err := i.connect(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This reduces the API surface of the issuers. This function doesn't need to be called by users, as they can simply call one of the Issuers functions if they want to pre-empt the lazy loading of certificates.

The CFSSL test ensures it works both with and without an explicit TLS config.