### PR TITLE
adds ability to configure mount point name for vault pki

### DIFF
--- a/issuers/cfssl/cfssl_suite_test.go
+++ b/issuers/cfssl/cfssl_suite_test.go
@@ -103,7 +103,6 @@ var _ = BeforeSuite(func() {
 				},
 			},
 			HostConfig: &docker.HostConfig{
-				NetworkMode:     "host",
 				PublishAllPorts: true,
 				PortBindings: map[docker.Port][]docker.PortBinding{
 					"8888": []docker.PortBinding{{HostPort: "8888"}},
@@ -217,7 +216,7 @@ var _ = BeforeSuite(func() {
 			Config: &docker.Config{
 				Image: img,
 				ExposedPorts: map[docker.Port]struct{}{
-					docker.Port("8888"): struct{}{},
+					docker.Port("8889"): struct{}{},
 				},
 				Cmd: []string{
 					"serve",
@@ -232,7 +231,6 @@ var _ = BeforeSuite(func() {
 				},
 			},
 			HostConfig: &docker.HostConfig{
-				NetworkMode:     "host",
 				PublishAllPorts: true,
 				PortBindings: map[docker.Port][]docker.PortBinding{
 					"8889": []docker.PortBinding{{HostPort: "8889"}},

--- a/issuers/vault/vault.go
+++ b/issuers/vault/vault.go
@@ -25,6 +25,9 @@ type Issuer struct {
 	// Token is the Vault secret token that should be used
 	// when issuing certificates.
 	Token string
+	// Mount is the name under which the PKI secrets engine
+	// is mounted. Defaults to `pki`
+	Mount string
 	// Role is the Vault Role that should be used
 	// when issuing certificates.
 	Role string
@@ -121,7 +124,12 @@ func (v *Issuer) Issue(ctx context.Context, commonName string, conf *certify.Cer
 }
 
 func (v Issuer) signCSR(ctx context.Context, opts csrOpts) (*api.Secret, error) {
-	r := v.cli.NewRequest("PUT", "/v1/pki/sign/"+v.Role)
+	pkiMountName := "pki"
+	if v.Mount != "" {
+		pkiMountName = v.Mount
+	}
+
+	r := v.cli.NewRequest("PUT", "/v1/"+pkiMountName+"/sign/"+v.Role)
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}

--- a/issuers/vault/vault_suite_test.go
+++ b/issuers/vault/vault_suite_test.go
@@ -32,6 +32,7 @@ func TestVault(t *testing.T) {
 
 type vaultConfig struct {
 	Role     string
+	Mount    string
 	Token    string
 	URL      *url.URL
 	CA       *x509.Certificate
@@ -43,8 +44,8 @@ var (
 	resource *dockertest.Resource
 	waiter   docker.CloseWaiter
 
-	vaultConf, vaultTLSConf vaultConfig
-	defaultTTL, maxTTL      time.Duration
+	vaultConf, vaultTLSConf, vaultMountConf vaultConfig
+	defaultTTL, maxTTL                      time.Duration
 )
 
 var _ = BeforeSuite(func() {
@@ -165,6 +166,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).To(Succeed())
 		cli.SetToken(token)
 
+		// Mount PKI at /pki
 		Expect(pool.Retry(func() error {
 			_, err := cli.Logical().Read("pki/certs")
 			return err
@@ -197,8 +199,46 @@ var _ = BeforeSuite(func() {
 		})
 		Expect(err).To(Succeed())
 
+		// Mount pki at /mount-test-pki
+		Expect(pool.Retry(func() error {
+			_, err := cli.Logical().Read("mount-test-pki/certs")
+			return err
+		})).To(Succeed())
+
+		Expect(cli.Sys().Mount("mount-test-pki", &api.MountInput{
+			Type: "pki",
+			Config: api.MountConfigInput{
+				MaxLeaseTTL: "87600h",
+			},
+		})).To(Succeed())
+		_, err = cli.Logical().Write("mount-test-pki/root/generate/internal", map[string]interface{}{
+			"ttl":         "87600h",
+			"common_name": "my_vault",
+			"ip_sans":     c.NetworkSettings.IPAddress,
+			"format":      "der",
+		})
+		Expect(err).To(Succeed())
+
+		_, err = cli.Logical().Write("mount-test-pki/roles/"+role, map[string]interface{}{
+			"allowed_domains":    "myserver.com",
+			"allow_subdomains":   true,
+			"allow_any_name":     true,
+			"key_type":           "any",
+			"allowed_other_sans": "1.3.6.1.4.1.311.20.2.3;utf8:*",
+		})
+		Expect(err).To(Succeed())
+
 		vaultConf = vaultConfig{
 			Token: token,
+			Role:  role,
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   net.JoinHostPort(host, "8200"),
+			},
+		}
+		vaultMountConf = vaultConfig{
+			Token: token,
+			Mount: "mount-test-pki",
 			Role:  role,
 			URL: &url.URL{
 				Scheme: "http",

--- a/issuers/vault/vault_suite_test.go
+++ b/issuers/vault/vault_suite_test.go
@@ -112,7 +112,6 @@ var _ = BeforeSuite(func() {
 				},
 			},
 			HostConfig: &docker.HostConfig{
-				NetworkMode:     "host",
 				PublishAllPorts: true,
 				PortBindings: map[docker.Port][]docker.PortBinding{
 					"8200": []docker.PortBinding{{HostPort: "8200"}},


### PR DESCRIPTION
Vault allows you to mount a secrets engine at an arbitrary name, but the CSR signing function was hard-coded to only request from the default `pki` mount name. This makes that name configurable via a new `Mount string` option in the `issuers.vault.Issuer` config. The configuration is optional and defaults to `"pki"` if not set to preserve compatibility.