### PR TITLE
Fixes Dir cache gob encoding, with tests

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -2,6 +2,9 @@ package certify
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
 	"crypto/tls"
 	"encoding/gob"
 	"errors"
@@ -10,6 +13,15 @@ import (
 	"path/filepath"
 	"sync"
 )
+
+func init() {
+	gob.Register(rsa.PrivateKey{})
+	gob.Register(ecdsa.PrivateKey{})
+	gob.Register(elliptic.P224())
+	gob.Register(elliptic.P256())
+	gob.Register(elliptic.P384())
+	gob.Register(elliptic.P521())
+}
 
 // Cache describes the interface that certificate caches must implement.
 // Cache implementations must be thread safe.

--- a/certify_suite_test.go
+++ b/certify_suite_test.go
@@ -3,6 +3,19 @@ package certify_test
 import (
 	"testing"
 
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -10,4 +23,71 @@ import (
 func TestCertify(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Certify Suite")
+}
+
+func generateCertAndKey(SAN string, IPSAN net.IP, keyFunc keyGeneratorFunc) (*tls.Certificate, error) {
+	priv, err := keyFunc.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Hour)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, err
+	}
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "Certify Test Cert",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{SAN},
+		IPAddresses:           []net.IP{IPSAN},
+	}
+
+	var (
+		pubKey     crypto.PublicKey
+		encodedKey []byte
+	)
+	switch p := priv.(type) {
+	case *rsa.PrivateKey:
+		pubKey = p.Public()
+		encodedKey = x509.MarshalPKCS1PrivateKey(p)
+	case *ecdsa.PrivateKey:
+		pubKey = p.Public()
+		encoded, err := x509.MarshalECPrivateKey(p)
+		if err != nil {
+			return nil, err
+		}
+		encodedKey = encoded
+	default:
+		return nil, fmt.Errorf("Unsupported key type")
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, pubKey, priv)
+	if err != nil {
+		return nil, err
+	}
+	certOut := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	})
+	keyOut := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: encodedKey,
+	})
+
+	cert, err := tls.X509KeyPair(certOut, keyOut)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cert, nil
 }

--- a/certify_suite_test.go
+++ b/certify_suite_test.go
@@ -1,8 +1,6 @@
 package certify_test
 
 import (
-	"testing"
-
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -14,6 +12,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
I noticed in my deployment that my cert cache was accumulating a large number of files. When I investigated I saw that every request was issuing a new cert from Vault but all the files in the cache were temporary files with random numbers appended.

Digging in, this was due to errors in the `DirCache.writeTempFile` method's gob encoding. When encoding interfaces (like `crypto.PrivateKey`), gob requires that the underlying concrete type be registered beforehand or you get errors like `"gob: type not registered for interface: elliptic.p256Curve"`, which is what I was getting. The error was being returned properly from `GetCertificate`, but I guess the builtin go `crypto/tls` was eating it because I had nothing in my server logs. This bug was not surfaced in the tests because the cert object passed through the cache tests was not a real cert, but just a stub that didn't have any of the problematic interfaces to marshal.

This PR does two things:

1. Adds an `init()` method to `cache.go` which registers the concrete implementations of `crypto.PrivateKey`: `rsa.PrivateKey` and `ecdsa.PrivateKey` (plus Curves).
2. Updates the test suite to test for this bug.