### PR TITLE
Remove golangci-lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,16 +31,6 @@ jobs:
       - run: go install ./vendor/github.com/golang/protobuf/protoc-gen-go ./vendor/github.com/matryer/moq
       - run: go generate -x ./...
       - run: git diff --exit-code
-  lint:
-    docker:
-      - image: golang:latest
-    # golangci-lint works best with GOPATH
-    working_directory: /go/src/github.com/johanbrandhorst/certify
-    steps:
-      - checkout
-      - run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0
-      - run: GO111MODULE=on go mod vendor
-      - run: ./bin/golangci-lint run
   test:
     machine:
       image: circleci/classic:edge
@@ -62,5 +52,4 @@ workflows:
       - build
       - vendor
       - generate
-      - lint
       - test


### PR DESCRIPTION
This is covered by a github extension instead.