### PR TITLE
Fixes missing Leaf in cert

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -3,6 +3,7 @@ package certify
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"

--- a/cache.go
+++ b/cache.go
@@ -98,6 +98,14 @@ func (d DirCache) Get(ctx context.Context, name string) (*tls.Certificate, error
 
 	go func() {
 		cert, err = tls.LoadX509KeyPair(name+certExt, name+keyExt)
+		if err == nil {
+			// Need to parse the Leaf manually for expiration checks
+			var leaf *x509.Certificate
+			leaf, err = x509.ParseCertificate(cert.Certificate[0])
+			if err == nil {
+				cert.Leaf = leaf
+			}
+		}
 		close(done)
 	}()
 

--- a/certify_suite_test.go
+++ b/certify_suite_test.go
@@ -88,5 +88,10 @@ func generateCertAndKey(SAN string, IPSAN net.IP, keyFunc keyGeneratorFunc) (*tl
 		return nil, err
 	}
 
+	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+
 	return &cert, nil
 }

--- a/certify_test.go
+++ b/certify_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Caches", func() {
 						Expect(c.Cache.Put(context.Background(), "key1", cert)).To(Succeed())
 						cached, err := c.Cache.Get(context.Background(), "key1")
 						Expect(err).To(Succeed())
+						Expect(cached.Leaf).To(Not(BeNil()))
 						Expect(cached).To(BeEquivalentTo(cert))
 						Expect(c.Cache.Delete(context.Background(), "key1")).To(Succeed())
 						_, err = c.Cache.Get(context.Background(), "key1")


### PR DESCRIPTION
The `tls.LoadX509KeyPair()` method does not populate the parsed certificate's `Leaf` member, which is used later to determine expiration. This causes a panic when loading from the cache.

The fix is to manually populate it by parsing the first cert in the chain with `x509.ParseCertificate()` and assigning that to the Leaf.