### PR TITLE
Add support for URI sans

### DIFF
--- a/issuers/vault/types.go
+++ b/issuers/vault/types.go
@@ -11,6 +11,7 @@ type csrOpts struct {
 	CommonName        string    `json:"common_name"`
 	ExcludeCNFromSANS bool      `json:"exclude_cn_from_sans"`
 	Format            string    `json:"format"`
+	URISans           otherSans `json:"uri_sans,omitempty"`
 	OtherSans         otherSans `json:"other_sans,omitempty"`
 	TimeToLive        ttl       `json:"ttl,omitempty"`
 }

--- a/issuers/vault/vault.go
+++ b/issuers/vault/vault.go
@@ -38,6 +38,10 @@ type Issuer struct {
 	// TimeToLive configures the lifetime of certificates
 	// requested from the Vault server.
 	TimeToLive time.Duration
+
+	// URISubjectAlternativeNames defines custom URI SANs.
+	URISubjectAlternativeNames []string
+
 	// OtherSubjectAlternativeNames defines custom OID/UTF8-string SANs.
 	// The format is the same as OpenSSL: <oid>;<type>:<value> where the only current valid <type> is UTF8.
 	OtherSubjectAlternativeNames []string
@@ -93,6 +97,7 @@ func (v *Issuer) Issue(ctx context.Context, commonName string, conf *certify.Cer
 		CommonName:        commonName,
 		ExcludeCNFromSANS: true,
 		Format:            "pem",
+		URISans:           v.URISubjectAlternativeNames,
 		OtherSans:         v.OtherSubjectAlternativeNames,
 		TimeToLive:        ttl(v.TimeToLive),
 	}


### PR DESCRIPTION
Note that the vault role needs to be use_csr_sans=false for the uri_sans to work (I suspect this is the same for other_sans already anyway) but this is fine for my use case.