### PR TITLE
Add noopCache to simplify some logic

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -264,3 +264,15 @@ func (d DirCache) writeTempCert(prefix string, cert *tls.Certificate) (string, e
 
 	return f.Name(), f.Close()
 }
+
+type noopCache struct{}
+
+func (*noopCache) Get(context.Context, string) (*tls.Certificate, error) {
+	return nil, ErrCacheMiss
+}
+func (*noopCache) Put(context.Context, string, *tls.Certificate) error {
+	return nil
+}
+func (*noopCache) Delete(context.Context, string) error {
+	return nil
+}


### PR DESCRIPTION
The noopCache is used when no caching is configured,
and means we can remove two nil checks.