### PR TITLE
Support setting URI SANs in CSRs

### DIFF
--- a/certify_test.go
+++ b/certify_test.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net"
+	"net/url"
 	"sync"
 	"time"
 
@@ -134,8 +135,9 @@ var _ = Describe("Certify", func() {
 			CommonName: "myserver.com",
 			Issuer:     issuer,
 			CertConfig: &certify.CertConfig{
-				SubjectAlternativeNames:   []string{"extraname.com"},
-				IPSubjectAlternativeNames: []net.IP{net.IPv4(1, 2, 3, 4)},
+				SubjectAlternativeNames:    []string{"extraname.com"},
+				IPSubjectAlternativeNames:  []net.IP{net.IPv4(1, 2, 3, 4)},
+				URISubjectAlternativeNames: []*url.URL{{Scheme: "https", Host: "example.org"}},
 			},
 			Logger: logger,
 		}
@@ -146,16 +148,18 @@ var _ = Describe("Certify", func() {
 			case 1:
 				// First call is GetCertificate
 				Expect(in3).To(PointTo(MatchAllFields(Fields{
-					"SubjectAlternativeNames":   Equal(append(cli.CertConfig.SubjectAlternativeNames, serverName, cli.CommonName)),
-					"IPSubjectAlternativeNames": Equal(cli.CertConfig.IPSubjectAlternativeNames),
-					"KeyGenerator":              Not(BeNil()),
+					"SubjectAlternativeNames":    Equal(append(cli.CertConfig.SubjectAlternativeNames, serverName, cli.CommonName)),
+					"IPSubjectAlternativeNames":  Equal(cli.CertConfig.IPSubjectAlternativeNames),
+					"URISubjectAlternativeNames": Equal(cli.CertConfig.URISubjectAlternativeNames),
+					"KeyGenerator":               Not(BeNil()),
 				})))
 			case 2:
 				// Second call is GetClientCertificate
 				Expect(in3).To(PointTo(MatchAllFields(Fields{
-					"SubjectAlternativeNames":   Equal(append(cli.CertConfig.SubjectAlternativeNames, cli.CommonName)),
-					"IPSubjectAlternativeNames": Equal(cli.CertConfig.IPSubjectAlternativeNames),
-					"KeyGenerator":              Not(BeNil()),
+					"SubjectAlternativeNames":    Equal(append(cli.CertConfig.SubjectAlternativeNames, cli.CommonName)),
+					"IPSubjectAlternativeNames":  Equal(cli.CertConfig.IPSubjectAlternativeNames),
+					"URISubjectAlternativeNames": Equal(cli.CertConfig.URISubjectAlternativeNames),
+					"KeyGenerator":               Not(BeNil()),
 				})))
 			}
 			pk, err := in3.KeyGenerator.Generate()
@@ -198,9 +202,10 @@ var _ = Describe("Certify", func() {
 				defer GinkgoRecover()
 				Expect(in2).To(Equal(cli.CommonName))
 				Expect(in3).To(PointTo(MatchAllFields(Fields{
-					"SubjectAlternativeNames":   Equal([]string{cli.CommonName}),
-					"IPSubjectAlternativeNames": BeEmpty(),
-					"KeyGenerator":              Not(BeNil()),
+					"SubjectAlternativeNames":    Equal([]string{cli.CommonName}),
+					"IPSubjectAlternativeNames":  BeEmpty(),
+					"URISubjectAlternativeNames": BeEmpty(),
+					"KeyGenerator":               Not(BeNil()),
 				})))
 				return &tls.Certificate{
 					Leaf: &x509.Certificate{
@@ -240,9 +245,10 @@ var _ = Describe("Certify", func() {
 					defer GinkgoRecover()
 					Expect(in2).To(Equal(cli.CommonName))
 					Expect(in3).To(PointTo(MatchAllFields(Fields{
-						"SubjectAlternativeNames":   Equal([]string{cli.CommonName}),
-						"IPSubjectAlternativeNames": BeEmpty(),
-						"KeyGenerator":              Not(BeNil()),
+						"SubjectAlternativeNames":    Equal([]string{cli.CommonName}),
+						"IPSubjectAlternativeNames":  BeEmpty(),
+						"URISubjectAlternativeNames": BeEmpty(),
+						"KeyGenerator":               Not(BeNil()),
 					})))
 					return &tls.Certificate{
 						Leaf: &x509.Certificate{
@@ -282,9 +288,10 @@ var _ = Describe("Certify", func() {
 				defer GinkgoRecover()
 				Expect(in2).To(Equal(cli.CommonName))
 				Expect(in3).To(PointTo(MatchAllFields(Fields{
-					"SubjectAlternativeNames":   Equal([]string{cli.CommonName}),
-					"IPSubjectAlternativeNames": Equal([]net.IP{net.ParseIP(serverName)}),
-					"KeyGenerator":              Not(BeNil()),
+					"SubjectAlternativeNames":    Equal([]string{cli.CommonName}),
+					"IPSubjectAlternativeNames":  Equal([]net.IP{net.ParseIP(serverName)}),
+					"URISubjectAlternativeNames": BeEmpty(),
+					"KeyGenerator":               Not(BeNil()),
 				})))
 				return &tls.Certificate{
 					Leaf: &x509.Certificate{
@@ -325,9 +332,10 @@ var _ = Describe("Certify", func() {
 				defer GinkgoRecover()
 				Expect(in2).To(Equal(cli.CommonName))
 				Expect(in3).To(PointTo(MatchAllFields(Fields{
-					"SubjectAlternativeNames":   Equal([]string{cli.CommonName}),
-					"IPSubjectAlternativeNames": Equal([]net.IP{net.ParseIP(serverName)}),
-					"KeyGenerator":              Not(BeNil()),
+					"SubjectAlternativeNames":    Equal([]string{cli.CommonName}),
+					"IPSubjectAlternativeNames":  Equal([]net.IP{net.ParseIP(serverName)}),
+					"URISubjectAlternativeNames": BeEmpty(),
+					"KeyGenerator":               Not(BeNil()),
 				})))
 				_, err := in3.KeyGenerator.Generate()
 				Expect(err).To(MatchError("test error"))
@@ -364,9 +372,10 @@ var _ = Describe("Certify", func() {
 				defer GinkgoRecover()
 				Expect(in2).To(Equal(cli.CommonName))
 				Expect(in3).To(PointTo(MatchAllFields(Fields{
-					"SubjectAlternativeNames":   Equal([]string{cli.CommonName}),
-					"IPSubjectAlternativeNames": BeEmpty(),
-					"KeyGenerator":              Not(BeNil()),
+					"SubjectAlternativeNames":    Equal([]string{cli.CommonName}),
+					"IPSubjectAlternativeNames":  BeEmpty(),
+					"URISubjectAlternativeNames": BeEmpty(),
+					"KeyGenerator":               Not(BeNil()),
 				})))
 				<-wait
 				return &tls.Certificate{

--- a/internal/csr/csr.go
+++ b/internal/csr/csr.go
@@ -32,6 +32,7 @@ func FromCertConfig(commonName string, conf *certify.CertConfig) ([]byte, []byte
 	if conf != nil {
 		template.DNSNames = conf.SubjectAlternativeNames
 		template.IPAddresses = conf.IPSubjectAlternativeNames
+		template.URIs = conf.URISubjectAlternativeNames
 	}
 
 	csr, err := x509.CreateCertificateRequest(rand.Reader, template, pk)

--- a/internal/csr/csr_test.go
+++ b/internal/csr/csr_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"net"
+	"net/url"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,8 +20,9 @@ import (
 var _ = Describe("FromCertConfig", func() {
 	It("Generates a CSR and a Key", func() {
 		conf := &certify.CertConfig{
-			SubjectAlternativeNames:   []string{"extraname.com"},
-			IPSubjectAlternativeNames: []net.IP{net.IPv4(1, 2, 3, 4)},
+			SubjectAlternativeNames:    []string{"extraname.com"},
+			IPSubjectAlternativeNames:  []net.IP{net.IPv4(1, 2, 3, 4)},
+			URISubjectAlternativeNames: []*url.URL{{Scheme: "https", Host: "example.com"}},
 			KeyGenerator: keyGeneratorFunc(func() (crypto.PrivateKey, error) {
 				return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 			}),
@@ -35,6 +37,7 @@ var _ = Describe("FromCertConfig", func() {
 		Expect(csr.PublicKey).To(BeAssignableToTypeOf(&ecdsa.PublicKey{}))
 		Expect(csr.Subject.CommonName).To(Equal("myserver.com"))
 		Expect(csr.DNSNames).To(Equal(conf.SubjectAlternativeNames))
+		Expect(csr.URIs).To(Equal(conf.URISubjectAlternativeNames))
 		for i, ip := range csr.IPAddresses {
 			Expect(ip.Equal(conf.IPSubjectAlternativeNames[i])).To(BeTrue())
 		}

--- a/issuer.go
+++ b/issuer.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/tls"
 	"net"
+	"net/url"
 )
 
 // Issuer is the interface that must be implemented
@@ -21,8 +22,9 @@ type KeyGenerator interface {
 // CertConfig configures the specifics of the certificate
 // requested from the Issuer.
 type CertConfig struct {
-	SubjectAlternativeNames   []string
-	IPSubjectAlternativeNames []net.IP
+	SubjectAlternativeNames    []string
+	IPSubjectAlternativeNames  []net.IP
+	URISubjectAlternativeNames []*url.URL
 	// KeyGenerator is used to create new private keys
 	// for CSR requests. If not defined, defaults to ECDSA P256.
 	// Only ECDSA and RSA keys are supported.
@@ -39,6 +41,7 @@ func (cc *CertConfig) Clone() *CertConfig {
 
 	newCC.SubjectAlternativeNames = cc.SubjectAlternativeNames
 	newCC.IPSubjectAlternativeNames = cc.IPSubjectAlternativeNames
+	newCC.URISubjectAlternativeNames = cc.URISubjectAlternativeNames
 	newCC.KeyGenerator = cc.KeyGenerator
 	return newCC
 }

--- a/issuers/vault/vault.go
+++ b/issuers/vault/vault.go
@@ -41,10 +41,22 @@ type Issuer struct {
 
 	// URISubjectAlternativeNames defines custom URI SANs.
 	// The format is a URI and must match the value specified in allowed_uri_sans, eg spiffe://hostname/foobar
+	//
+	// Warning: By default Vault reads URI SANs directly from the
+	// Certificate Signing Request (CSR), and ignores this field completely.
+	// This field only takes effect when the Vault role has set use_csr_sans to false,
+	// and using this setting will ignore any SANs in the CSR.
+	//
+	// To configure URI SANs directly in the CSR, set CertConfig.URISubjectAlternativeNames,
 	URISubjectAlternativeNames []string
 
 	// OtherSubjectAlternativeNames defines custom OID/UTF8-string SANs.
 	// The format is the same as OpenSSL: <oid>;<type>:<value> where the only current valid <type> is UTF8.
+	//
+	// Warning: By default Vault reads SANs directly from the
+	// Certificate Signing Request (CSR), and ignores this field completely.
+	// This field only takes effect when the Vault role has set use_csr_sans to false,
+	// and using this setting will ignore any SANs in the CSR.
 	OtherSubjectAlternativeNames []string
 
 	cli *api.Client


### PR DESCRIPTION
In #70 support was added to the Vault issuer to allow setting URI SANs.
The particular fix leaves two things to be desired:

(1) It is Vault-specific
(2) It interacts with other configuration options in an unfortunate way.

While (1) is self-explanatory, (2) deserves more explanation.

With Vault, you have a binary knob: either take SANs from the
CSR or from the Vault API request. In order to set URI SANs
with the support in #70, one can configure Vault to take all SANs
from the API request. But if you do this you lose the ability to set
DNS SANs, since this functionality is only supported in Certify through
the base certify.CertConfig which ends up setting SANs on the CSR itself
(which is now being ignored by Vault). If you do not set this flag in
Vault the URI SANs specified through the vault.Issuer are ignored.

To summarize, there is no way with any combination of Certify
configuration and Vault configuration to specify both URI SANs
and DNS SANs.

This commit addresses that limitation, by supporting setting URI SANs
directly on the CSR. This has been supported since Go 1.10.