### PR TITLE
Reuse keys by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,14 @@ jobs:
     working_directory: /home/circleci/.go_workspace/src/github.com/johanbrandhorst/certify
     steps:
       - checkout
-      - run: go get github.com/lpar/goup
-      - run: sudo rm -rf /usr/local/go
-      - run: yes | sudo /home/circleci/.go_workspace/bin/goup --force --os linux --arch amd64 || true # swallow exit 141
+      - run:
+          name: Update Go installation
+          command: |
+            wget https://github.com/lpar/goup/releases/download/1.0/goup-linux-x64.xz &&
+            xz --decompress goup-linux-x64.xz &&
+            chmod +x goup-linux-x64
+            sudo rm -rf /usr/local/go &&
+            yes | sudo ./goup-linux-x64 --force --os linux --arch amd64 || true # swallow exit 141
       - run: go install github.com/onsi/ginkgo/ginkgo
       - run: ginkgo -v -r -coverprofile=coverage.txt -cover --randomizeAllSpecs --randomizeSuites --failOnPending --trace --race --progress --skipPackage=vendor --skipMeasurements
       - run: bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Releases](https://img.shields.io/github/release/johanbrandhorst/certify.svg?style=flat-square)](https://github.com/johanbrandhorst/certify/releases)
 [![License](https://img.shields.io/github/license/johanbrandhorst/certify.svg?style=flat-square)](LICENSE)
 [![Join the chat at https://gitter.im/go-certify/community](https://img.shields.io/gitter/room/go-certify/community.svg?style=flat-square)](https://gitter.im/go-certify/community)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjohanbrandhorst%2Fcertify.svg?type=small)](https://app.fossa.io/projects/git%2Bgithub.com%2Fjohanbrandhorst%2Fcertify?ref=badge_small)
 
 ![Certify](logo.png "Certify")
 
@@ -107,6 +106,3 @@ requests, the configured `CommonName` is used.
 My presentation at the London HashiCorp meetup has more information:
 
 [![Certify presentation](https://img.youtube.com/vi/4We8yg9yefA/0.jpg)](https://www.youtube.com/watch?v=4We8yg9yefA)
-
-## License
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjohanbrandhorst%2Fcertify.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fjohanbrandhorst%2Fcertify?ref=badge_large)

--- a/certify.go
+++ b/certify.go
@@ -2,10 +2,6 @@ package certify
 
 import (
 	"context"
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"errors"
 	"strings"
@@ -71,9 +67,7 @@ func (c *Certify) init() {
 		c.CertConfig = &CertConfig{}
 	}
 	if c.CertConfig.KeyGenerator == nil {
-		c.CertConfig.KeyGenerator = keyGeneratorFunc(func() (crypto.PrivateKey, error) {
-			return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		})
+		c.CertConfig.KeyGenerator = &singletonKey{}
 	}
 }
 
@@ -183,10 +177,4 @@ func (c *Certify) getOrRenewCert(name string) (*tls.Certificate, error) {
 		}
 		return res.Val.(*tls.Certificate), nil
 	}
-}
-
-type keyGeneratorFunc func() (crypto.PrivateKey, error)
-
-func (kgf keyGeneratorFunc) Generate() (crypto.PrivateKey, error) {
-	return kgf()
 }

--- a/keys.go
+++ b/keys.go
@@ -1,0 +1,23 @@
+package certify
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"sync"
+)
+
+type singletonKey struct {
+	key crypto.PrivateKey
+	err error
+	o   sync.Once
+}
+
+func (s *singletonKey) Generate() (crypto.PrivateKey, error) {
+	s.o.Do(func() {
+		s.key, s.err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	})
+
+	return s.key, s.err
+}


### PR DESCRIPTION
This changes the behaviour of the default KeyGenerator
to reuse the same key for new certificates, instead of
performing an expensive regeneration every time we issue
a new CSR.

Fixes #99 