### PR TITLE
Add AuthMethod to Vault issuer

### DIFF
--- a/issuer.go
+++ b/issuer.go
@@ -28,7 +28,7 @@ type CertConfig struct {
 	// KeyGenerator is used to create new private keys
 	// for CSR requests. If not defined, defaults to ECDSA P256.
 	// Only ECDSA and RSA keys are supported.
-	// This is guaranteed to be privided in Issue calls.
+	// This is guaranteed to be provided in Issue calls.
 	KeyGenerator KeyGenerator
 }
 

--- a/issuers/vault/types.go
+++ b/issuers/vault/types.go
@@ -1,9 +1,27 @@
 package vault
 
 import (
+	"context"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/vault/api"
 )
+
+// AuthMethod defines the interface required to implement
+// custom authentication against the Vault server.
+type AuthMethod interface {
+	GetToken(context.Context, *api.Client) (string, error)
+}
+
+// ConstantToken implements AuthMethod with a constant token
+type ConstantToken string
+
+// GetToken returns the token
+func (c ConstantToken) GetToken(context.Context, *api.Client) (string, error) {
+	return string(c), nil
+}
+
 
 // https://www.vaultproject.io/api/secret/pki/index.html#parameters-14
 type csrOpts struct {


### PR DESCRIPTION
## Add AuthMethod to Vault issuer

AuthMethod replaces the Token field. It is used to
configure the token used for the Vault API requests.
ConstantToken is equivalent to the old Token field.

