### PR TITLE
Add renewable token auth method to Vault issuer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,23 @@ jobs:
     steps:
       - checkout
       - run: go build ./...
+  format:
+    docker:
+      - image: golang:latest
+    steps:
+      - checkout
+      - run:
+          name: Install gofumports outside local module
+          command: |
+            cd $(mktemp -d) &&
+            go mod init tmp &&
+            go get mvdan.cc/gofumpt/gofumports@latest
+      - run:
+          name: Run gofumports on all non-generated files
+          command: grep -L -R "^\/\/ Code generated .* DO NOT EDIT\.$" --exclude-dir=.git --exclude-dir=vendor --include="*.go" | xargs -n 1 gofumports -w -local github.com/johanbrandhorst/certify
+      - run:
+          name: Check for any changes
+          command: git diff --exit-code
   vendor:
     docker:
       - image: golang:latest
@@ -59,6 +76,7 @@ workflows:
   all:
     jobs:
       - build
+      - format
       - vendor
       - generate
       - test

--- a/cache.go
+++ b/cache.go
@@ -270,9 +270,11 @@ type noopCache struct{}
 func (*noopCache) Get(context.Context, string) (*tls.Certificate, error) {
 	return nil, ErrCacheMiss
 }
+
 func (*noopCache) Put(context.Context, string, *tls.Certificate) error {
 	return nil
 }
+
 func (*noopCache) Delete(context.Context, string) error {
 	return nil
 }

--- a/issuers/vault/types.go
+++ b/issuers/vault/types.go
@@ -2,7 +2,9 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/vault/api"
@@ -18,11 +20,157 @@ type AuthMethod interface {
 type ConstantToken string
 
 // SetToken sets the clients token to the constant token value.
-func (c ConstantToken) SetToken(_ context.Context, cli *api.Client) (error) {
+func (c ConstantToken) SetToken(_ context.Context, cli *api.Client) error {
 	cli.SetToken(string(c))
 	return nil
 }
 
+// RenewingToken is used for automatically renewing
+// the token used to authenticate with Vault. RenewingToken
+// requires SetToken to be called at least once before the
+// expiry of the initial token.
+type RenewingToken struct {
+	// Initial is the token used to initially
+	// authenticate against Vault. It must be
+	// renewable.
+	Initial string
+	// RenewBefore configures how long before the expiry
+	// of the token it should be renewed. Defaults
+	// to 30 minutes before expiry.
+	RenewBefore time.Duration
+	// TimeToLive configures how long the new token
+	// should be valid for. Defaults to 24 hours.
+	TimeToLive time.Duration
+
+	o sync.Once
+
+	token   string
+	tokenMu sync.Mutex
+	errC    chan error
+	cancel func()
+}
+
+// SetToken implements AuthMethod for RenewingToken.
+func (r *RenewingToken) SetToken(ctx context.Context, cli *api.Client) error {
+	var err error
+	r.o.Do(func() {
+		cli.SetToken(string(r.Initial))
+		r.token = r.Initial
+		if r.RenewBefore <= 0 {
+			r.RenewBefore = 30 * time.Minute
+		}
+		if r.TimeToLive <= 0 {
+			r.TimeToLive = 24 * time.Hour
+		}
+		r.errC = make(chan error)
+
+		req := cli.NewRequest("GET", "/v1/auth/token/lookup-self")
+		resp, tErr := cli.RawRequestWithContext(ctx, req)
+		if tErr != nil {
+			err = tErr
+			return
+		}
+		defer resp.Body.Close()
+	
+		tok, tErr := api.ParseSecret(resp.Body)
+		if tErr != nil {
+			err = tErr
+			return
+		}
+
+		rn, tErr := tok.TokenIsRenewable()
+		if tErr != nil {
+			err = tErr
+			return
+		}
+
+		if !rn {
+			err = fmt.Errorf("token was not renewable")
+			return
+		}
+
+		ttl, tErr := tok.TokenTTL()
+		if tErr != nil {
+			err = tErr
+			return
+		}
+
+		// Start background process for renewing the token
+		var cctx context.Context
+		cctx, r.cancel = context.WithCancel(context.Background())
+		go func() {
+			for {
+				wait := ttl - r.RenewBefore
+				if wait < time.Second {
+					// Wait for at least one second, in case we somehow end up
+					// with a very short wait.
+					wait = time.Second
+				}
+
+				tk := time.NewTicker(wait)
+
+				select {
+				case <-cctx.Done():
+					return
+				case <-tk.C:
+					tk.Stop()
+				}
+
+				// Needs renewal
+				req := cli.NewRequest("PUT", "/v1/auth/token/renew-self")
+			
+				body := map[string]interface{}{"increment": r.TimeToLive.Seconds()}
+				if err := req.SetJSONBody(body); err != nil {
+					r.errC <- err
+					return
+				}
+				resp, tErr := cli.RawRequestWithContext(cctx, req)
+				if tErr != nil {
+					r.errC <- err
+					return
+				}
+				defer resp.Body.Close()
+			
+				tok, tErr := api.ParseSecret(resp.Body)
+				if tErr != nil {
+					r.errC <- err
+					return
+				}
+				if err != nil {
+					r.errC <- err
+					return
+				}
+
+				r.tokenMu.Lock()
+				r.token = tok.Auth.ClientToken
+				r.tokenMu.Unlock()
+				ttl = r.TimeToLive
+			}
+		}()
+	})
+	if err != nil {
+		return err
+	}
+
+	select {
+	case err = <-r.errC:
+		return err
+	default:
+	}
+
+	r.tokenMu.Lock()
+	tok := r.token
+	r.tokenMu.Unlock()
+	cli.SetToken(tok)
+
+	return nil
+}
+
+// Close can be used to release resources associated with the token.
+func (r *RenewingToken) Close() error {
+	r.cancel()
+	return nil
+}
 
 // https://www.vaultproject.io/api/secret/pki/index.html#parameters-14
 type csrOpts struct {

--- a/issuers/vault/types.go
+++ b/issuers/vault/types.go
@@ -11,15 +11,16 @@ import (
 // AuthMethod defines the interface required to implement
 // custom authentication against the Vault server.
 type AuthMethod interface {
-	GetToken(context.Context, *api.Client) (string, error)
+	SetToken(context.Context, *api.Client) error
 }
 
 // ConstantToken implements AuthMethod with a constant token
 type ConstantToken string
 
-// GetToken returns the token
-func (c ConstantToken) GetToken(context.Context, *api.Client) (string, error) {
-	return string(c), nil
+// SetToken sets the clients token to the constant token value.
+func (c ConstantToken) SetToken(_ context.Context, cli *api.Client) (error) {
+	cli.SetToken(string(c))
+	return nil
 }
 
 

--- a/issuers/vault/types.go
+++ b/issuers/vault/types.go
@@ -47,7 +47,7 @@ type RenewingToken struct {
 	token   string
 	tokenMu sync.Mutex
 	errC    chan error
-	cancel func()
+	cancel  func()
 }
 
 // SetToken implements AuthMethod for RenewingToken.
@@ -71,7 +71,7 @@ func (r *RenewingToken) SetToken(ctx context.Context, cli *api.Client) error {
 			return
 		}
 		defer resp.Body.Close()
-	
+
 		tok, tErr := api.ParseSecret(resp.Body)
 		if tErr != nil {
 			err = tErr
@@ -118,7 +118,7 @@ func (r *RenewingToken) SetToken(ctx context.Context, cli *api.Client) error {
 
 				// Needs renewal
 				req := cli.NewRequest("PUT", "/v1/auth/token/renew-self")
-			
+
 				body := map[string]interface{}{"increment": r.TimeToLive.Seconds()}
 				if err := req.SetJSONBody(body); err != nil {
 					r.errC <- err
@@ -130,7 +130,7 @@ func (r *RenewingToken) SetToken(ctx context.Context, cli *api.Client) error {
 					return
 				}
 				defer resp.Body.Close()
-			
+
 				tok, tErr := api.ParseSecret(resp.Body)
 				if tErr != nil {
 					r.errC <- err

--- a/issuers/vault/vault.go
+++ b/issuers/vault/vault.go
@@ -162,11 +162,10 @@ func (v Issuer) signCSR(ctx context.Context, opts csrOpts) (*api.Secret, error) 
 	}
 
 	// Update token immediately before making the request
-	token, err := v.AuthMethod.GetToken(ctx, v.cli)
+	err := v.AuthMethod.SetToken(ctx, v.cli)
 	if err != nil {
 		return nil, err
 	}
-	v.cli.SetToken(token)
 
 	r := v.cli.NewRequest("PUT", "/v1/"+pkiMountName+"/sign/"+v.Role)
 	if err := r.SetJSONBody(opts); err != nil {

--- a/issuers/vault/vault.go
+++ b/issuers/vault/vault.go
@@ -75,9 +75,9 @@ type Issuer struct {
 // the token already defined in the client for authentication.
 func FromClient(v *api.Client, role string) *Issuer {
 	return &Issuer{
-		Role: role,
+		Role:       role,
 		AuthMethod: ConstantToken(v.Token()),
-		cli:  v,
+		cli:        v,
 	}
 }
 

--- a/issuers/vault/vault_test.go
+++ b/issuers/vault/vault_test.go
@@ -65,9 +65,9 @@ var _ = Describe("Vault Issuer", func() {
 
 	BeforeEach(func() {
 		iss = &vault.Issuer{
-			URL:   vaultTLSConf.URL,
+			URL:        vaultTLSConf.URL,
 			AuthMethod: vault.ConstantToken(vaultTLSConf.Token),
-			Role:  vaultTLSConf.Role,
+			Role:       vaultTLSConf.Role,
 			TLSConfig: &tls.Config{
 				RootCAs: vaultTLSConf.CertPool,
 			},
@@ -109,19 +109,19 @@ var _ = Describe("Vault Issuer", func() {
 	Context("with no explicit AuthMethod set", func() {
 		It("still works", func() {
 			cn := "somename.com"
-	
+
 			tlsCert, err := iss.Issue(context.Background(), cn, conf)
 			Expect(err).NotTo(HaveOccurred())
-	
+
 			Expect(tlsCert.Leaf).NotTo(BeNil(), "tlsCert.Leaf should be populated by Issue to track expiry")
 			Expect(tlsCert.Leaf.Subject.CommonName).To(Equal(cn))
-	
+
 			// Check that chain is included
 			Expect(tlsCert.Certificate).To(HaveLen(2))
 			caCert, err := x509.ParseCertificate(tlsCert.Certificate[1])
 			Expect(err).NotTo(HaveOccurred())
 			Expect(caCert.Subject.SerialNumber).To(Equal(tlsCert.Leaf.Issuer.SerialNumber))
-	
+
 			Expect(tlsCert.Leaf.NotBefore).To(BeTemporally("<", time.Now()))
 			Expect(tlsCert.Leaf.NotAfter).To(BeTemporally("~", time.Now().Add(iss.(*vault.Issuer).TimeToLive), 5*time.Second))
 			Expect(getOtherNames(tlsCert.Leaf)).To(ConsistOf(otherName{
@@ -134,9 +134,9 @@ var _ = Describe("Vault Issuer", func() {
 	Context("with URI SANs", func() {
 		BeforeEach(func() {
 			iss = &vault.Issuer{
-				URL:   vaultTLSConf.URL,
+				URL:        vaultTLSConf.URL,
 				AuthMethod: vault.ConstantToken(vaultTLSConf.Token),
-				Role:  vaultTLSConf.RoleURISANs,
+				Role:       vaultTLSConf.RoleURISANs,
 				TLSConfig: &tls.Config{
 					RootCAs: vaultTLSConf.CertPool,
 				},
@@ -172,10 +172,10 @@ var _ = Describe("Vault Issuer", func() {
 	Context("with a non-standard mount point", func() {
 		BeforeEach(func() {
 			iss = &vault.Issuer{
-				URL:   vaultTLSConf.URL,
+				URL:        vaultTLSConf.URL,
 				AuthMethod: vault.ConstantToken(vaultTLSConf.Token),
-				Mount: altMount,
-				Role:  vaultTLSConf.Role,
+				Mount:      altMount,
+				Role:       vaultTLSConf.Role,
 				TLSConfig: &tls.Config{
 					RootCAs: vaultTLSConf.CertPool,
 				},
@@ -485,9 +485,9 @@ var _ = Describe("When using RenewingToken", func() {
 		}()
 
 		iss := &vault.Issuer{
-			URL: vaultTLSConf.URL,
+			URL:        vaultTLSConf.URL,
 			AuthMethod: rt,
-			Role: vaultTLSConf.Role,
+			Role:       vaultTLSConf.Role,
 			TLSConfig: &tls.Config{
 				RootCAs: vaultTLSConf.CertPool,
 			},
@@ -503,7 +503,7 @@ var _ = Describe("When using RenewingToken", func() {
 		_, err = iss.Issue(context.Background(), cn, conf)
 		Expect(err).To(Succeed())
 
-		time.Sleep(2*time.Second) // Should cause token to be renewed in the background.
+		time.Sleep(2 * time.Second) // Should cause token to be renewed in the background.
 
 		_, err = iss.Issue(context.Background(), cn, conf)
 		Expect(err).To(Succeed())
@@ -554,9 +554,9 @@ var _ = Describe("gRPC Test", func() {
 				cb = &certify.Certify{
 					CommonName: "Certify",
 					Issuer: &vault.Issuer{
-						URL:   vaultTLSConf.URL,
+						URL:        vaultTLSConf.URL,
 						AuthMethod: vault.ConstantToken(vaultTLSConf.Token),
-						Role:  vaultTLSConf.Role,
+						Role:       vaultTLSConf.Role,
 						TLSConfig: &tls.Config{
 							RootCAs: vaultTLSConf.CertPool,
 						},


### PR DESCRIPTION
## Change AuthMethod to mutate client directly

This removes an unnecessary call when updating
the token dynamically.

## Add RenewingToken to Vault issuer

RenewingToken configures an automatically
renewing token authentication method. It requires
a renewable token, and will automatically renew the
token when it falls within the renewal threshold. This
is managed in a separate goroutine, whose lifetime
can be controlled with the Close method.

## Run gofumports on source 